### PR TITLE
Refresh token jwk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "http": "^0.0.1-security",
         "https": "^1.0.0",
         "imgbb-uploader": "^1.5.1",
+        "js-cookie": "^3.0.5",
         "prettier": "^3.0.3",
         "proxy": "^2.1.1",
         "querystring": "^0.2.1",
@@ -13104,6 +13105,14 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "peer": true
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "http": "^0.0.1-security",
     "https": "^1.0.0",
     "imgbb-uploader": "^1.5.1",
+    "js-cookie": "^3.0.5",
     "prettier": "^3.0.3",
     "proxy": "^2.1.1",
     "querystring": "^0.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -58,6 +58,7 @@ function App() {
             <Route path='openProj' element={<OpenProj />} />
             <Route path='newProj' element={<NewProj />} />
             <Route path='deadlineProj' element={<DeadlineProj />} />
+            <Route path='project2' element={<ProjectData2 />} />
             <Route path='searchPage' element={<SearchPage />} />
             <Route path='searchPage/:keyword' element={<SearchPage />} />
           </Route>
@@ -65,7 +66,7 @@ function App() {
           <Route path='/signup' element={<AuthSignup />} />
           <Route path='/idpwFind' element={<IdpwFind />} />
           <Route path='/*' element={<NotFound />} />
-          <Route path='/project2' element={<ProjectData2 />} />
+
           <Route path='/projectPay' element={<ProjectPay />} />
           <Route path='/reward' element={<RewardSelect />} />
           <Route path='/reduxTest' element={<ReduxTest />} />

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -10,7 +10,7 @@ export default function Header() {
   // 리덕스에서 로그인 상태 확인
   const isLogin = useSelector((state) => state.auth.auth.isLogin);
   // 리덕스에서 운영자 확인
-  const isAdmin = useSelector((state) => state.auth.auth.isAdmin);
+  const isAdmin = useSelector((state) => state.userData.userData.isAdmin);
 
   const { keyword } = useParams();
   const navigate = useNavigate();

--- a/src/components/HigherOrderComponents/Auth.jsx
+++ b/src/components/HigherOrderComponents/Auth.jsx
@@ -7,6 +7,8 @@ export default function Auth(SpecificComponent, option, adminRoute = null) {
   function AuthenticationCheck(props) {
     // 리덕스에서 _id 가져오기
     const _id = useSelector((state) => state._id._id);
+    // 리덕스에서 isAdmin 가져오기
+    const isAdmin = useSelector((state) => state.userData.userData.isAdmin)
     const [loading, setLoading] = useState(true);
     const dispatch = useDispatch();
     const navigate = useNavigate();
@@ -23,7 +25,7 @@ export default function Auth(SpecificComponent, option, adminRoute = null) {
           }
         } else {
           //로그인 한 상태
-          if (adminRoute && !res.payload.isAdmin) {
+          if (adminRoute && !isAdmin) {
             navigate('/home');
           } else {
             if (option === false) {

--- a/src/components/HigherOrderComponents/Auth.jsx
+++ b/src/components/HigherOrderComponents/Auth.jsx
@@ -1,17 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { setAuth } from '../../redux/reducer/authAction';
 
 export default function Auth(SpecificComponent, option, adminRoute = null) {
   function AuthenticationCheck(props) {
+    // 리덕스에서 _id 가져오기
+    const _id = useSelector((state) => state._id._id);
     const [loading, setLoading] = useState(true);
     const dispatch = useDispatch();
     const navigate = useNavigate();
     const location = useLocation();
     useEffect(() => {
       const fetchData = async () => {
-        const res = await dispatch(setAuth());
+        const res = await dispatch(setAuth(_id));
         setLoading(false); // 요청이 완료되면 로딩 상태를 false로 변경
 
         //로그인 하지 않은 상태

--- a/src/components/HigherOrderComponents/Auth.jsx
+++ b/src/components/HigherOrderComponents/Auth.jsx
@@ -16,6 +16,10 @@ export default function Auth(SpecificComponent, option, adminRoute = null) {
     useEffect(() => {
       const fetchData = async () => {
         const res = await dispatch(setAuth(_id));
+        if(res.payload.accessToken !== ''){
+          console.log(res.payload.accessToken);
+          localStorage.setItem('x_auth', res.payload.accessToken);
+        }
         setLoading(false); // 요청이 완료되면 로딩 상태를 false로 변경
 
         //로그인 하지 않은 상태

--- a/src/components/Pages/ComingProject/ComingNotice.jsx
+++ b/src/components/Pages/ComingProject/ComingNotice.jsx
@@ -15,10 +15,10 @@ export default function ComingNotice() {
   const isLogin = useSelector((state) => state.auth.auth.isLogin);
 
   // 리덕스에서 userId 가져오기
-  const userId = useSelector((state) => state.auth.auth.userId);
+  const userId = useSelector((state) => state.userData.userData.userId);
 
   // 리덕스에서 관리자여부 가져오기
-  const isAdmin = useSelector((state) => state.auth.auth.isAdmin);
+  const isAdmin = useSelector((state) => state.userData.userData.isAdmin);
 
   // React Router의 useLocation 훅을 사용하여 현재 위치 가져오기
   const location = useLocation();

--- a/src/components/Pages/Home.jsx
+++ b/src/components/Pages/Home.jsx
@@ -6,6 +6,7 @@ import Slide from '../Slide/Slide';
 import { Outlet } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ProjApiProvider } from '../../context/ProjectsApiContext';
+import ProjectData2 from '../ProjectData/ProjectDetail/ProjectData2';
 // import ProjectRanking from './ProjectRanking';
 
 const queryClient = new QueryClient({

--- a/src/components/Pages/MemberService/CreateProj/CreateProj.jsx
+++ b/src/components/Pages/MemberService/CreateProj/CreateProj.jsx
@@ -11,6 +11,7 @@ import { height } from "@mui/system";
 import AddressSearch from "../Address/AddressSearch";
 
 const CreateProj = () => {
+  axios.defaults.withCredentials = false;
   const [state, setState] = useState({
     projTag: "0",
     projRegion: "0",
@@ -254,8 +255,8 @@ const CreateProj = () => {
           }
         }
       }
-      console.log(state);
       const uploadImgUrl = await uploadImage(state.imageBase64)
+      console.log(uploadImgUrl);
       // state에서 imageBase64를 제외한 속성을 postData로 복사
       const { imageBase64, ...postData } = state; 
       await axios.post(`${endpoint}/createProj`, {

--- a/src/components/Pages/MemberService/CreateProj/CreateProj.jsx
+++ b/src/components/Pages/MemberService/CreateProj/CreateProj.jsx
@@ -165,8 +165,8 @@ const CreateProj = () => {
   const dispatch = useDispatch();
   
   // 리덕스의 userName, userId, userAddr 가져오기
-  const userName = useSelector((state) => state.auth.auth.userName)
-  const userId = useSelector((state) => state.auth.auth.userId)
+  const userName = useSelector((state) => state.userData.userData.userName)
+  const userId = useSelector((state) => state.userData.userData.userId)
   const projPlace = useSelector((state) => {
     const projPlaceAddr = state.projPlaceAddr?.projPlaceAddr;
     return projPlaceAddr ? projPlaceAddr.projPlace : undefined;

--- a/src/components/Pages/MemberService/Login.jsx
+++ b/src/components/Pages/MemberService/Login.jsx
@@ -10,8 +10,11 @@ import { setUserMail } from '../../../redux/reducer/userMailActions';
 import { MemberShipContainer, MemberShipDivCenter, MemberShipInput, MemberShipInputShort, MemberShipButton, MemberShipButtonShort } from '../../../css/MemberService/MemberShipCss'
 import Endpoint from '../../../config/Endpoint';
 import '../../../css/MemberService/Login.css'
+import { setId } from '../../../redux/reducer/idAction';
+import { setUserData } from '../../../redux/reducer/userDataAction';
 
 export const Login = () => {
+  axios.defaults.withCredentials = true;
   const endpoint = Endpoint();
   const navigate = useNavigate();
   const userMailRef = useRef();  // 사용자에게 입력받은 userMail을 Ref로 통해서 추적해요
@@ -56,8 +59,10 @@ export const Login = () => {
           dispatch(setUserAddr(res.data.userAddr));
           dispatch(setUserPhoneNum(res.data.userPhoneNum));
           dispatch(setUserMail(res.data.userMail));
-          //로컬스토리지 x_auth에 토큰 저장
-          localStorage.setItem('x_auth', res.data.token);
+          dispatch(setId(res.data._id));
+          dispatch(setUserData(res.data));
+          //로컬스토리지 x_auth에 엑세스토큰 저장
+          localStorage.setItem('x_auth', res.data.accessToken);
           if (location.state && location.state.from) {
             navigate(location.state.from);
           } else {

--- a/src/components/Pages/MemberService/Logout.jsx
+++ b/src/components/Pages/MemberService/Logout.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import axios from 'axios';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import Endpoint from '../../../config/Endpoint';
 
 export const Logout = () => {
   const endpoint = Endpoint();
   const navigate = useNavigate();
-  const token = localStorage.getItem('x_auth');
+  const _id = useSelector((state) => state._id._id);
   const handleLogoutClick = () => {
-    axios.get(`${endpoint}/logout`, {
-      headers: {
-        authorization: `Bearer ${token}`, // Bearer 스키마를 사용하는 토큰 전달
-      },
+    axios.post(`${endpoint}/logout`, {
+      _id
     }).then(res => {
       if(res.data.logoutSuccess){
+        localStorage.removeItem('x_auth');
         navigate('/home');
         window.location.reload();
       } else {

--- a/src/components/Pages/MemberService/ModifyProj/ModifyProj.jsx
+++ b/src/components/Pages/MemberService/ModifyProj/ModifyProj.jsx
@@ -204,8 +204,8 @@ export default function ModifyProj() {
   const dispatch = useDispatch();
   
   // 리덕스의 userName, userId, userAddr 가져오기
-  const userName = useSelector((state) => state.auth.auth.userName)
-  const userId = useSelector((state) => state.auth.auth.userId)
+  const userName = useSelector((state) => state.userData.userData.userName)
+  const userId = useSelector((state) => state.userData.userData.userId)
   const projPlace = useSelector((state) => {
     const projPlaceAddr = state.projPlaceAddr?.projPlaceAddr;
     return projPlaceAddr ? projPlaceAddr.projPlace : undefined;

--- a/src/components/Pages/Mypage/FundingProject.jsx
+++ b/src/components/Pages/Mypage/FundingProject.jsx
@@ -70,8 +70,7 @@ export default function FundingProject() {
     })
 
   }
-  console.log(fundings)
-  console.log(fundingProject);
+
   return (
       <>
         {mount && fundingProject.map((projectArray, index) => {

--- a/src/components/Pages/Mypage/FundingProject.jsx
+++ b/src/components/Pages/Mypage/FundingProject.jsx
@@ -12,7 +12,7 @@ export default function FundingProject() {
   const endpoint = Endpoint();
   const [modalIsOpen, setModalIsOpen] = useState(false);
   // 리덕스의 userId 가져오기
-  const user_id = useSelector((state) => state.auth.auth.userId)
+  const user_id = useSelector((state) => state.userData.userData.userId)
 
   const [fundings, setFundings] = useState();
   const [fundingProject, setFundingProject] = useState();

--- a/src/components/Pages/Mypage/LikeProject.jsx
+++ b/src/components/Pages/Mypage/LikeProject.jsx
@@ -9,7 +9,7 @@ export default function LikeProject() {
 	// Like프로젝트는 리덕스의 userId를 가져와서 userprojects에서 
 	// 해당 users_id에서 userLikeProject를 가져와 projects 에서 userLikeProject와 proj_id가 같은걸 가져옴
 	// 리덕스의 userId 가져오기
-  const user_id = useSelector((state) => state.auth.auth.userId)
+  const user_id = useSelector((state) => state.userData.userData.userId)
 	// 데이터 불러올때까지 mount 값 false
   const [mount, setMount] = useState(false);
 	// likeProject에 서버로부터 받아온 값 넣어주기

--- a/src/components/Pages/Mypage/MadeProject.jsx
+++ b/src/components/Pages/Mypage/MadeProject.jsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 
 export default function MadeProject() {
 	// 리덕스의 userId 가져오기
-  const user_id = useSelector((state) => state.auth.auth.userId)
+  const user_id = useSelector((state) => state.userData.userData.userId)
   // 데이터 불러올때까지 mount 값 false
   const [mount, setMount] = useState(false);
 

--- a/src/components/Pages/Mypage/Mypage.jsx
+++ b/src/components/Pages/Mypage/Mypage.jsx
@@ -8,7 +8,7 @@ import UserProfileModify from './UserProfileModify';
 
 export default function Mypage() {
   // 리덕스의 userName 가져오기
-  const userName = useSelector((state) => state.auth.auth.userName)
+  const userName = useSelector((state) => state.userData.userData.userName)
   // 펀딩프로젝트는 fundings 컬렉션에서 user_id가 현재 리덕스 userId랑 일치하는것만 가져와서 project_id 와 projects 컬렉션의 proj_id가 일치하는것만 뿌림
   // 펀딩프로젝트에서 필요한 데이터는 projects 의 projName, projAddr, projPlace // fundings 의 rewards 갯수로 map 돌려서 반복
 

--- a/src/components/Pages/Mypage/UserProfileModify.jsx
+++ b/src/components/Pages/Mypage/UserProfileModify.jsx
@@ -16,11 +16,11 @@ export default function UserProfileModify() {
 	const [userPasswordCheck, setUserPasswordCheck] = useState('');
   const userPhoneNumRef = useRef();
 	// 리덕스 정보 가져오기
-	const userId = useSelector((state) => state.auth.auth.userId)
-	const userMail = useSelector((state) => state.auth.auth.userMail)
-	const userName = useSelector((state) => state.auth.auth.userName)
-	const userPhoneNum = useSelector((state) => state.auth.auth.userPhoneNum)
-	const authUserAddr = useSelector((state) => state.auth.auth.userAddr)
+	const userId = useSelector((state) => state.userData.userData.userId)
+	const userMail = useSelector((state) => state.userData.userData.userMail)
+	const userName = useSelector((state) => state.userData.userData.userName)
+	const userPhoneNum = useSelector((state) => state.userData.userData.userPhoneNum)
+	const authUserAddr = useSelector((state) => state.userData.userData.userAddr)
 	const userAddr = useSelector((state) => state.userAddr.userAddr)
 
 	// 회원가입 수정 버튼을 누르면 데이터 서버로 넘김

--- a/src/components/Pages/ProjectRankingThumbnail.jsx
+++ b/src/components/Pages/ProjectRankingThumbnail.jsx
@@ -17,10 +17,10 @@ export default function ProjectRankingThumbnail(props) {
         ? props.isAdmin === true || props.userId === props.maderId
           ? navigate('/comingProj', { state: { _id: props.projId } })
           : alert('오픈예정 프로젝트입니다.')
-        : navigate('/project2', { state: { _id: props.projId } }); // 진행중 --> 상세페이지로
+        : navigate('/home/project2', { state: { _id: props.projId } }); // 진행중 --> 상세페이지로
     } else if (props.projStatus === '2') {
       // 마감된(2) --> 프로젝트 상세페이지로
-      navigate('/project2', { state: { _id: props.projId } });
+      navigate('/home/project2', { state: { _id: props.projId } });
     } else if (props.projStatus === '3') {
       // 거절된(3) --> 경고창
       alert('승인거절된 프로젝트입니다.');

--- a/src/components/Pages/Thumbnail.jsx
+++ b/src/components/Pages/Thumbnail.jsx
@@ -48,10 +48,10 @@ export default function Thumbnail({
         ? isLogin && (isAdmin === true || userId === maderId)
           ? navigate('/comingProj', { state: { _id: projId } })
           : alert('오픈예정 프로젝트입니다.')
-        : navigate('/project2', { state: { _id: projId } }); // 진행중 --> 상세페이지로
+        : navigate('/home/project2', { state: { _id: projId } }); // 진행중 --> 상세페이지로
     } else if (projStatus === '2') {
       // 마감된(2) --> 프로젝트 상세페이지로
-      navigate('/project2', { state: { _id: projId } });
+      navigate('/home/project2', { state: { _id: projId } });
     } else if (projStatus === '3') {
       // 거절된(3) --> 경고창
       alert('승인거절된 프로젝트입니다.');

--- a/src/components/Pages/Thumbnail.jsx
+++ b/src/components/Pages/Thumbnail.jsx
@@ -31,8 +31,8 @@ export default function Thumbnail({
   // console.log(`오늘: ${today}, 시작일: ${sday}`);
 
   /* ----- 리덕스의 userId, isAdmin. isLogin 가져오기 ----- */
-  const userId = useSelector((state) => state.auth.auth['_id']); // 로그인한 userID
-  const isAdmin = useSelector((state) => state.auth.auth.isAdmin); // 서비스 관리자 여부: true=관리자
+  const userId = useSelector((state) => state.userData.userData['_id']); // 로그인한 userID
+  const isAdmin = useSelector((state) => state.userData.userData.isAdmin); // 서비스 관리자 여부: true=관리자
   const isLogin = useSelector((state) => state.auth.auth.isLogin); // 로그인 여부
 
   const openProjDetails = () => {

--- a/src/components/ProjectData/ProjectDetail/ProjectData2.jsx
+++ b/src/components/ProjectData/ProjectDetail/ProjectData2.jsx
@@ -4,12 +4,21 @@ import MenuTabs from '../Menu/MenuTabs';
 import RewardSelect from '../RewardSelect/RewardSelect';
 import './ProjectData2.css'
 import { useLocation } from 'react-router';
+import { useProjectsApi } from '../../../context/ProjectsApiContext';
+import { useQuery } from '@tanstack/react-query';
 
 function ProjectData2() {
     const location = useLocation();
     const { _id } = location.state || {};
+    const { projects } = useProjectsApi();
+    const {
+        data: projectData,
+        } = useQuery({
+        queryKey: ['projects'],
+        queryFn: () => projects.getProjects(),
+    });
 
-    const projectData = useFetch("https://json-server-vercel-sepia-omega.vercel.app/projects");
+    /* const projectData = useFetch("https://json-server-vercel-sepia-omega.vercel.app/projects"); */
 
     if (!projectData) {
         return <div>Loading...</div>;

--- a/src/components/ProjectData/RewardSelect/RewardSelect.jsx
+++ b/src/components/ProjectData/RewardSelect/RewardSelect.jsx
@@ -15,10 +15,10 @@ const RewardSelect = () => {
   const isLogin = useSelector((state) => state.auth.auth.isLogin);
 
   // 리덕스에서 userId 가져오기
-  const userId = useSelector((state) => state.auth.auth.userId);
+  const userId = useSelector((state) => state.userData.userData.userId);
 
   // 리덕스에서 관리자여부 가져오기
-  const isAdmin = useSelector((state) => state.auth.auth.isAdmin);
+  const isAdmin = useSelector((state) => state.userData.userData.isAdmin);
 
   // React Router의 useLocation 훅을 사용하여 현재 위치 가져오기
   const location = useLocation();

--- a/src/components/Slide/Slide.jsx
+++ b/src/components/Slide/Slide.jsx
@@ -69,7 +69,7 @@ export default function Slide() {
   // );
 
   const toProjectPage = (proj_id) => {
-    navigate('/project2', { state: { _id: proj_id } });
+    navigate('/home/project2', { state: { _id: proj_id } });
   };
 
   // 슬라이더 설정

--- a/src/redux/reducer/authAction.js
+++ b/src/redux/reducer/authAction.js
@@ -1,18 +1,15 @@
-import Cookies from 'js-cookie';
 import axios from 'axios';
 import Endpoint from '../../config/Endpoint';
 
-export const setAuth = (_id) => {
+export const setAuth = async (_id) => {
   const endpoint = Endpoint();
   // 로컬스토리지에서 토큰을 가져오는 부분을 추가
   const token = localStorage.getItem('x_auth');
-  const refreshToken = Cookies.get('refresh_token');
   // 헤더에 토큰을 포함하여 요청을 보내도록 수정
-  const request = axios
+  const request = await axios
     .get(`${endpoint}/auth`, {
       headers: {
         authorization: `Bearer ${token}`, // Bearer 스키마를 사용하는 토큰 전달
-        'x-refresh-token': refreshToken, // 리프레쉬 토큰
       },
       params: { _id }, // _id를 쿼리 매개변수로 전달
     })

--- a/src/redux/reducer/authAction.js
+++ b/src/redux/reducer/authAction.js
@@ -1,17 +1,20 @@
+import Cookies from 'js-cookie';
 import axios from 'axios';
 import Endpoint from '../../config/Endpoint';
 
-export const setAuth = () => {
+export const setAuth = (_id) => {
   const endpoint = Endpoint();
   // 로컬스토리지에서 토큰을 가져오는 부분을 추가
   const token = localStorage.getItem('x_auth');
-
+  const refreshToken = Cookies.get('refresh_token');
   // 헤더에 토큰을 포함하여 요청을 보내도록 수정
   const request = axios
     .get(`${endpoint}/auth`, {
       headers: {
         authorization: `Bearer ${token}`, // Bearer 스키마를 사용하는 토큰 전달
+        'x-refresh-token': refreshToken, // 리프레쉬 토큰
       },
+      params: { _id }, // _id를 쿼리 매개변수로 전달
     })
     .then((res) => res.data);
 

--- a/src/redux/reducer/authReducer.js
+++ b/src/redux/reducer/authReducer.js
@@ -9,6 +9,7 @@ export const authReducer = (
       userName: null,
       userPhoneNum: null,
       userMail: null,
+      accessToken: null,
     },
   },
   action

--- a/src/redux/reducer/idAction.js
+++ b/src/redux/reducer/idAction.js
@@ -1,0 +1,4 @@
+export const setId = (_id) => ({
+  type: 'SET_ID',
+  payload: _id,
+});

--- a/src/redux/reducer/idReducer.js
+++ b/src/redux/reducer/idReducer.js
@@ -1,0 +1,11 @@
+export const idReducer = (state = {}, action) => {
+  switch (action.type) {
+    case 'SET_ID':
+      return {
+        ...state,
+        _id: action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/redux/reducer/userDataAction.js
+++ b/src/redux/reducer/userDataAction.js
@@ -1,0 +1,4 @@
+export const setUserData = (data) => ({
+  type: 'SET_USERDATA',
+  payload: data,
+});

--- a/src/redux/reducer/userDataReducer.js
+++ b/src/redux/reducer/userDataReducer.js
@@ -1,0 +1,25 @@
+export const userDataReducer = (
+  state = {
+    userData: {
+      _id: null,
+      isLogin: false,
+      isAdmin: false,
+      userId: null,
+      userAddr: null,
+      userName: null,
+      userPhoneNum: null,
+      userMail: null,
+    },
+  },
+  action
+) => {
+  switch (action.type) {
+    case 'SET_USERDATA':
+      return {
+        ...state,
+        userData: action.payload,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -10,6 +10,8 @@ import { authReducer } from './reducer/authReducer';
 import { userPhoneNumReducer } from './reducer/userPhoneNumReducer';
 import { userMailReducer } from './reducer/userMailReducer';
 import { projPlaceAddrReducer } from './reducer/projPlaceAddrReducer';
+import { idReducer } from './reducer/idReducer';
+import { userDataReducer } from './reducer/userDataReducer';
 // 일단은 이렇게 변수 하나당 한개의 리듀서로 가다가
 // 최종안 나오면 user끼리 project끼리 합치는게 나을거같아요.
 
@@ -22,6 +24,8 @@ const rootReducer = combineReducers({
   projStatus: projStatusReducer,
   auth: authReducer,
   projPlaceAddr: projPlaceAddrReducer,
+  _id: idReducer,
+  userData: userDataReducer,
 });
 
 export const store = createStore(


### PR DESCRIPTION
변경점
1. 기존 JWT 토큰 이용방식은 엑세스토큰만 운용하며 몽고DB에 저장해서 일일이 유저를 다 확인하고 만료까지 서버에서 다 관리
    -> 엑세스토큰, 리프레쉬토큰을 같이 운용하고 엑세스토큰은 몽고DB에 저장하지않고 유효성만 확인하며, 리프레쉬토큰은 서버에 저장
    -> 엑세스토큰이 만료돼도 리프레쉬토큰이 만료되지 않았다면 자동적으로 엑세스토큰을 재발급 해주도록 바꿈


2. auth 리덕스 수정
    -> auth.auth._id 같은 정보들을 userData.userData._id 로 이전
    -> auth.auth 에는 기존의 isLogin 과 새로만든 accessToken 만 존재


3. projectData2 에 몽고DB 연결
     -> 기존 성민님이 만드신 contextAPI를 재활용하기위해 projectData2의 주소를 변경 (/home/projects2) 